### PR TITLE
feat(confluence): support creating subpages under specified parent page with related config, API and UI updates

### DIFF
--- a/confluence-test.html
+++ b/confluence-test.html
@@ -19,12 +19,27 @@
             margin-bottom: 5px;
             font-weight: bold;
         }
-        input, textarea {
+        input, textarea, select {
             width: 100%;
             padding: 8px;
             border: 1px solid #ddd;
             border-radius: 4px;
             box-sizing: border-box;
+        }
+        .inline-group {
+            display: flex;
+            gap: 10px;
+        }
+        .inline-group select {
+            flex: 1;
+        }
+        .inline-group button {
+            flex-shrink: 0;
+        }
+        .help-text {
+            margin-top: 6px;
+            font-size: 12px;
+            color: #666;
         }
         button {
             background-color: #4CAF50;
@@ -62,150 +77,225 @@
     </style>
 </head>
 <body>
-    <h1>🔍 Confluence API 测试工具</h1>
-    <p>用于测试 Cloudflare Tunnel + Confluence 的连接问题</p>
+<h1>🔍 Confluence API 测试工具</h1>
+<p>用于测试 Cloudflare Tunnel + Confluence 的连接问题</p>
 
-    <div class="form-group">
-        <label for="baseUrl">Confluence 地址:</label>
-        <input type="text" id="baseUrl" value="https://confluence.ocean-zhc.com.cn" placeholder="https://confluence.your-domain.com">
+<div class="form-group">
+    <label for="baseUrl">Confluence 地址:</label>
+    <input type="text" id="baseUrl" value="https://confluence.ocean-zhc.com.cn" placeholder="https://confluence.your-domain.com">
+</div>
+
+<div class="form-group">
+    <label for="token">Personal Access Token:</label>
+    <input type="password" id="token" placeholder="输入你的 Confluence Personal Access Token">
+</div>
+
+<div class="form-group">
+    <label for="spaceKey">空间 Key (可选，用于测试创建页面):</label>
+    <input type="text" id="spaceKey" placeholder="例如: DEV, TECH 等">
+</div>
+
+<div class="form-group">
+    <label for="parentPageId">父页面 ID (可选):</label>
+    <div class="inline-group">
+        <select id="parentPageId" disabled>
+            <option value="">不选择父页面</option>
+        </select>
+        <button type="button" onclick="loadParentPages()">刷新父页面</button>
     </div>
+    <div class="help-text">先填写空间 Key 后刷新，下拉列表会显示页面标题及 ID，例如 ocean-zhc+s 的知识库 (327683)。</div>
+</div>
 
-    <div class="form-group">
-        <label for="token">Personal Access Token:</label>
-        <input type="password" id="token" placeholder="输入你的 Confluence Personal Access Token">
-    </div>
+<h3>测试选项：</h3>
+<button onclick="testGetSpaces()">1. 测试获取空间列表 (GET)</button>
+<button onclick="testCreatePage()">2. 测试创建页面 (POST)</button>
+<button onclick="testHeaders()">3. 测试请求头是否完整</button>
 
-    <div class="form-group">
-        <label for="spaceKey">空间 Key (可选，用于测试创建页面):</label>
-        <input type="text" id="spaceKey" placeholder="例如: DEV, TECH 等">
-    </div>
+<div id="result" class="result" style="display: none;"></div>
 
-    <h3>测试选项：</h3>
-    <button onclick="testGetSpaces()">1. 测试获取空间列表 (GET)</button>
-    <button onclick="testCreatePage()">2. 测试创建页面 (POST)</button>
-    <button onclick="testHeaders()">3. 测试请求头是否完整</button>
+<script>
+    function getConfig(options = {}) {
+        const { requireSpaceKey = false, showError = true } = options;
+        const baseUrl = document.getElementById('baseUrl').value.trim();
+        const token = document.getElementById('token').value.trim();
+        const spaceKey = document.getElementById('spaceKey').value.trim();
+        const parentPageId = document.getElementById('parentPageId').value.trim();
 
-    <div id="result" class="result" style="display: none;"></div>
-
-    <script>
-        function getConfig() {
-            const baseUrl = document.getElementById('baseUrl').value.trim();
-            const token = document.getElementById('token').value.trim();
-            const spaceKey = document.getElementById('spaceKey').value.trim();
-            
-            if (!baseUrl || !token) {
+        if (!baseUrl || !token) {
+            if (showError) {
                 showResult('请填写 Confluence 地址和 Token！', 'error');
-                return null;
             }
-            
-            return { baseUrl, token, spaceKey };
+            return null;
         }
 
-        function showResult(message, type = 'success') {
-            const resultDiv = document.getElementById('result');
-            resultDiv.textContent = message;
-            resultDiv.className = 'result ' + type;
-            resultDiv.style.display = 'block';
-        }
-
-        async function testGetSpaces() {
-            const config = getConfig();
-            if (!config) return;
-
-            showResult('正在测试获取空间列表...', 'warning');
-
-            try {
-                const response = await fetch(`${config.baseUrl}/rest/api/space?limit=10`, {
-                    method: 'GET',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${config.token}`,
-                        'X-Atlassian-Token': 'no-check',
-                        'Accept': 'application/json',
-                    }
-                });
-
-                const data = await response.text();
-                let result = `状态码: ${response.status} ${response.statusText}\n\n`;
-                result += `响应头:\n`;
-                response.headers.forEach((value, key) => {
-                    result += `  ${key}: ${value}\n`;
-                });
-                result += `\n响应体:\n${data}`;
-
-                if (response.ok) {
-                    showResult('✅ 成功！\n\n' + result, 'success');
-                } else {
-                    showResult('❌ 失败！\n\n' + result, 'error');
-                }
-            } catch (error) {
-                showResult(`❌ 请求异常：\n${error.message}\n\n可能是网络错误或 CORS 问题`, 'error');
-            }
-        }
-
-        async function testCreatePage() {
-            const config = getConfig();
-            if (!config) return;
-
-            if (!config.spaceKey) {
+        if (requireSpaceKey && !spaceKey) {
+            if (showError) {
                 showResult('请填写空间 Key！', 'error');
-                return;
             }
-
-            showResult('正在测试创建页面...', 'warning');
-
-            const testData = {
-                type: 'page',
-                title: `API 测试页面 - ${new Date().toISOString()}`,
-                space: {
-                    key: config.spaceKey
-                },
-                body: {
-                    storage: {
-                        value: '<p>这是一个测试页面，用于验证 API 功能。</p><p>如果你看到这个页面，说明 API 调用成功！</p>',
-                        representation: 'storage'
-                    }
-                }
-            };
-
-            try {
-                const response = await fetch(`${config.baseUrl}/rest/api/content`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${config.token}`,
-                        'X-Atlassian-Token': 'no-check',
-                        'Accept': 'application/json',
-                    },
-                    body: JSON.stringify(testData)
-                });
-
-                const data = await response.text();
-                let result = `状态码: ${response.status} ${response.statusText}\n\n`;
-                result += `响应头:\n`;
-                response.headers.forEach((value, key) => {
-                    result += `  ${key}: ${value}\n`;
-                });
-                result += `\n响应体:\n${data}`;
-
-                if (response.ok) {
-                    showResult('✅ 成功创建页面！\n\n' + result, 'success');
-                } else {
-                    showResult('❌ 创建失败！\n\n' + result, 'error');
-                }
-            } catch (error) {
-                showResult(`❌ 请求异常：\n${error.message}\n\n可能是网络错误或 CORS 问题`, 'error');
-            }
+            return null;
         }
 
-        async function testHeaders() {
-            const config = getConfig();
-            if (!config) return;
+        return { baseUrl, token, spaceKey, parentPageId };
+    }
 
-            showResult('正在测试请求头...', 'warning');
+    function showResult(message, type = 'success') {
+        const resultDiv = document.getElementById('result');
+        resultDiv.textContent = message;
+        resultDiv.className = 'result ' + type;
+        resultDiv.style.display = 'block';
+    }
 
-            // 使用 httpbin.org 的镜像服务来查看实际发送的请求头
-            showResult(`
+    async function testGetSpaces() {
+        const config = getConfig();
+        if (!config) return;
+
+        showResult('正在测试获取空间列表...', 'warning');
+
+        try {
+            const response = await fetch(`${config.baseUrl}/rest/api/space?limit=10`, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${config.token}`,
+                    'X-Atlassian-Token': 'no-check',
+                    'Accept': 'application/json',
+                }
+            });
+
+            const data = await response.text();
+            let result = `状态码: ${response.status} ${response.statusText}\n\n`;
+            result += `响应头:\n`;
+            response.headers.forEach((value, key) => {
+                result += `  ${key}: ${value}\n`;
+            });
+            result += `\n响应体:\n${data}`;
+
+            if (response.ok) {
+                showResult('✅ 成功！\n\n' + result, 'success');
+            } else {
+                showResult('❌ 失败！\n\n' + result, 'error');
+            }
+        } catch (error) {
+            showResult(`❌ 请求异常：\n${error.message}\n\n可能是网络错误或 CORS 问题`, 'error');
+        }
+    }
+
+    async function loadParentPages(showError = true) {
+        const parentSelect = document.getElementById('parentPageId');
+        const config = getConfig({ requireSpaceKey: true, showError });
+        if (!config) {
+            parentSelect.innerHTML = '<option value="">不选择父页面</option>';
+            parentSelect.disabled = true;
+            return;
+        }
+
+        parentSelect.disabled = true;
+        parentSelect.innerHTML = '<option value="">加载中...</option>';
+
+        try {
+            const response = await fetch(`${config.baseUrl}/rest/api/content?spaceKey=${encodeURIComponent(config.spaceKey)}&type=page&limit=200&expand=ancestors`, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${config.token}`,
+                    'X-Atlassian-Token': 'no-check',
+                    'Accept': 'application/json',
+                }
+            });
+
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`${response.status} ${response.statusText}: ${text}`);
+            }
+
+            const data = await response.json();
+            const currentValue = config.parentPageId;
+            const options = ['<option value="">不选择父页面</option>'];
+            (data.results || []).forEach((page) => {
+                const label = `${page.title} (${page.id})`;
+                options.push(`<option value="${page.id}">${label}</option>`);
+            });
+
+            parentSelect.innerHTML = options.join('');
+            parentSelect.disabled = false;
+            if (currentValue) {
+                parentSelect.value = currentValue;
+                if (parentSelect.value !== currentValue) {
+                    parentSelect.value = '';
+                }
+            }
+        } catch (error) {
+            parentSelect.innerHTML = '<option value="">加载失败，请重试</option>';
+            showResult(`❌ 父页面加载失败：\n${error.message}`, 'error');
+        }
+    }
+
+    async function testCreatePage() {
+        const config = getConfig({ requireSpaceKey: true });
+        if (!config) return;
+
+        showResult('正在测试创建页面...', 'warning');
+
+        const testData = {
+            type: 'page',
+            title: `API 测试页面 - ${new Date().toISOString()}`,
+            space: {
+                key: config.spaceKey
+            },
+            body: {
+                storage: {
+                    value: '<p>这是一个测试页面，用于验证 API 功能。</p><p>如果你看到这个页面，说明 API 调用成功！</p>',
+                    representation: 'storage'
+                }
+            }
+        };
+
+        if (config.parentPageId) {
+            testData.ancestors = [
+                {
+                    id: config.parentPageId
+                }
+            ];
+        }
+
+        try {
+            const response = await fetch(`${config.baseUrl}/rest/api/content`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${config.token}`,
+                    'X-Atlassian-Token': 'no-check',
+                    'Accept': 'application/json',
+                },
+                body: JSON.stringify(testData)
+            });
+
+            const data = await response.text();
+            let result = `状态码: ${response.status} ${response.statusText}\n\n`;
+            result += `响应头:\n`;
+            response.headers.forEach((value, key) => {
+                result += `  ${key}: ${value}\n`;
+            });
+            result += `\n响应体:\n${data}`;
+
+            if (response.ok) {
+                showResult('✅ 成功创建页面！\n\n' + result, 'success');
+            } else {
+                showResult('❌ 创建失败！\n\n' + result, 'error');
+            }
+        } catch (error) {
+            showResult(`❌ 请求异常：\n${error.message}\n\n可能是网络错误或 CORS 问题`, 'error');
+        }
+    }
+
+    async function testHeaders() {
+        const config = getConfig();
+        if (!config) return;
+
+        showResult('正在测试请求头...', 'warning');
+
+        // 使用 httpbin.org 的镜像服务来查看实际发送的请求头
+        showResult(`
 📋 检查清单：
 
 1. 打开浏览器开发者工具 (F12)
@@ -235,11 +325,17 @@ A) 在 Cloudflare 控制台配置：
 B) 或者直接使用内网地址：
    在插件配置中使用 Confluence 的内网地址
    例如: http://192.168.x.x:8090
-   
+
 C) 或者配置 Cloudflare Tunnel 允许所有头部：
    在 cloudflared 配置中添加 originRequest 设置
             `, 'warning');
+    }
+
+    document.getElementById('spaceKey').addEventListener('blur', () => {
+        if (document.getElementById('spaceKey').value.trim()) {
+            loadParentPages(false);
         }
-    </script>
+    });
+</script>
 </body>
 </html>

--- a/src/adaptors/api/confluence/confluenceApiAdaptor.ts
+++ b/src/adaptors/api/confluence/confluenceApiAdaptor.ts
@@ -34,311 +34,337 @@ import { ObjectUtil } from "zhi-common"
  * @see [Confluence REST API](https://developer.atlassian.com/cloud/confluence/rest/v1/intro/)
  */
 class ConfluenceApiAdaptor extends BaseBlogApi {
-  constructor(appInstance: any, cfg: ConfluenceConfig) {
-    super(appInstance, cfg)
-    this.logger = createAppLogger("confluence-api-adaptor")
-  }
+    protected declare cfg: ConfluenceConfig
 
-  public async getUsersBlogs(): Promise<UserBlog[]> {
-    const result: UserBlog[] = []
-
-    const spaces = await this.getSpaces()
-    // 数据适配
-    spaces.forEach((item: any) => {
-      const userblog: UserBlog = new UserBlog()
-      userblog.blogid = item.key
-      userblog.blogName = item.name
-      userblog.url = item.key
-      result.push(userblog)
-    })
-
-    return result
-  }
-
-  public async newPost(post: Post, publish?: boolean): Promise<string> {
-    // 确保最新的文章ID都包含了空间信息
-    const spaceKey = post.cate_slugs?.[0] ?? this.cfg.blogid
-    return await this.createPage(post.title, post.description, spaceKey)
-  }
-
-  public async editPost(postid: string, post: Post, publish?: boolean): Promise<boolean> {
-    const confluencePostidKey = this.getConfluencePostidKey(postid)
-    return await this.updatePage(
-      confluencePostidKey.pageId,
-      post.title,
-      post.description,
-      confluencePostidKey.spaceKey
-    )
-  }
-
-  public async deletePost(postid: string): Promise<boolean> {
-    const confluencePostidKey = this.getConfluencePostidKey(postid)
-    return await this.deletePage(confluencePostidKey.pageId)
-  }
-
-  public async getPost(postid: string, useSlug?: boolean): Promise<Post> {
-    const confluencePostidKey = this.getConfluencePostidKey(postid)
-
-    const page = await this.getPage(confluencePostidKey.pageId)
-    this.logger.debug("confluence page=>", page)
-
-    const commonPost = new Post()
-    commonPost.title = page.title
-    commonPost.description = page.body?.storage?.value || ""
-
-    // Confluence 空间
-    const space = page.space
-    const catSlugs = []
-    catSlugs.push(space.key)
-    commonPost.cate_slugs = catSlugs
-
-    return commonPost
-  }
-
-  public async getCategories(): Promise<CategoryInfo[]> {
-    const cats = [] as CategoryInfo[]
-
-    const spaces: any[] = await this.getSpaces()
-    if (spaces && spaces.length > 0) {
-      spaces.forEach((space) => {
-        const cat = new CategoryInfo()
-        cat.categoryId = space.key
-        cat.categoryName = space.name
-        cat.description = space.name
-        cat.categoryDescription = space.name
-        cats.push(cat)
-      })
+    constructor(appInstance: any, cfg: ConfluenceConfig) {
+        super(appInstance, cfg)
+        this.cfg = cfg
+        this.logger = createAppLogger("confluence-api-adaptor")
     }
 
-    return cats
-  }
+    public async getUsersBlogs(): Promise<UserBlog[]> {
+        const result: UserBlog[] = []
 
-  public async getPreviewUrl(postid: string): Promise<string> {
-    const purl = this.cfg.previewUrl ?? ""
-    const confluencePostidKey = this.getConfluencePostidKey(postid)
-    const pageId = confluencePostidKey.pageId
-    const spaceKey = confluencePostidKey.spaceKey ?? this.cfg.blogid ?? ""
-    const postUrl = purl.replace("[postid]", pageId).replace("[spaceKey]", spaceKey)
-    return postUrl
-  }
+        const spaces = await this.getSpaces()
+        // 数据适配
+        spaces.forEach((item: any) => {
+            const userblog: UserBlog = new UserBlog()
+            userblog.blogid = item.key
+            userblog.blogName = item.name
+            userblog.url = item.key
+            result.push(userblog)
+        })
 
-  // ================
-  // private methods
-  // ================
-
-  /**
-   * 获取 Confluence 空间列表
-   */
-  private async getSpaces() {
-    const url = "/rest/api/space"
-    const params = {
-      limit: 100,
-    }
-    const result = await this.confluenceRequest(url, params, "GET")
-    this.logger.debug("confluence spaces=>", result)
-    return result.results || []
-  }
-
-  /**
-   * 创建 Confluence 页面
-   *
-   * @param title 标题
-   * @param content 内容（HTML格式）
-   * @param spaceKey 空间key
-   */
-  private async createPage(title: string, content: string, spaceKey?: string): Promise<string> {
-    const url = "/rest/api/content"
-    const targetSpaceKey = spaceKey || this.cfg.blogid
-    
-    const params = {
-      type: "page",
-      title: title,
-      space: {
-        key: targetSpaceKey,
-      },
-      body: {
-        storage: {
-          value: content,
-          representation: "storage",
-        },
-      },
-    }
-    
-    const result = await this.confluenceRequest(url, params, "POST")
-    this.logger.debug("confluence createPage=>", result)
-    
-    if (!result || !result.id) {
-      throw new Error("请求 Confluence API 异常")
+        return result
     }
 
-    // 包含了空间key需要返回标识空间的ID，否则更新可能报错
-    if (targetSpaceKey) {
-      return `${result.id}_${targetSpaceKey}`
-    } else {
-      return `${result.id}`
-    }
-  }
-
-  /**
-   * 更新 Confluence 页面
-   *
-   * @param pageId 页面ID
-   * @param title 标题
-   * @param content 内容（HTML格式）
-   * @param spaceKey 空间key
-   */
-  private async updatePage(
-    pageId: string,
-    title: string,
-    content: string,
-    spaceKey?: string
-  ): Promise<boolean> {
-    // 先获取页面当前版本
-    const page = await this.getPage(pageId)
-    const currentVersion = page.version.number
-
-    const url = `/rest/api/content/${pageId}`
-    const params = {
-      id: pageId,
-      type: "page",
-      title: title,
-      version: {
-        number: currentVersion + 1,
-      },
-      body: {
-        storage: {
-          value: content,
-          representation: "storage",
-        },
-      },
+    public async newPost(post: Post, publish?: boolean): Promise<string> {
+        // 确保最新的文章ID都包含了空间信息
+        const spaceKey = post.cate_slugs?.[0] ?? this.cfg.blogid
+        return await this.createPage(post.title, post.description, spaceKey)
     }
 
-    const result = await this.confluenceRequest(url, params, "PUT")
-    if (!result) {
-      throw new Error("请求 Confluence API 异常")
+    public async editPost(postid: string, post: Post, publish?: boolean): Promise<boolean> {
+        const confluencePostidKey = this.getConfluencePostidKey(postid)
+        return await this.updatePage(
+            confluencePostidKey.pageId,
+            post.title,
+            post.description,
+            confluencePostidKey.spaceKey
+        )
     }
 
-    return true
-  }
-
-  /**
-   * 获取 Confluence 页面
-   *
-   * @param pageId 页面ID
-   */
-  private async getPage(pageId: string): Promise<any> {
-    const url = `/rest/api/content/${pageId}`
-    const params = {
-      expand: "body.storage,version,space",
-    }
-    const result = await this.confluenceRequest(url, params, "GET")
-    
-    if (!result) {
-      throw new Error("请求 Confluence API 异常")
+    public async deletePost(postid: string): Promise<boolean> {
+        const confluencePostidKey = this.getConfluencePostidKey(postid)
+        return await this.deletePage(confluencePostidKey.pageId)
     }
 
-    return result
-  }
+    public async getPost(postid: string, useSlug?: boolean): Promise<Post> {
+        const confluencePostidKey = this.getConfluencePostidKey(postid)
 
-  /**
-   * 删除 Confluence 页面
-   *
-   * @param pageId 页面ID
-   */
-  private async deletePage(pageId: string): Promise<boolean> {
-    const url = `/rest/api/content/${pageId}`
-    const result = await this.confluenceRequest(url, {}, "DELETE")
-    
-    if (!result) {
-      throw new Error("请求 Confluence API 异常")
+        const page = await this.getPage(confluencePostidKey.pageId)
+        this.logger.debug("confluence page=>", page)
+
+        const commonPost = new Post()
+        commonPost.title = page.title
+        commonPost.description = page.body?.storage?.value || ""
+
+        // Confluence 空间
+        const space = page.space
+        const catSlugs = []
+        catSlugs.push(space.key)
+        commonPost.cate_slugs = catSlugs
+
+        return commonPost
     }
 
-    return true
-  }
+    public async getCategories(): Promise<CategoryInfo[]> {
+        const cats = [] as CategoryInfo[]
 
-  /**
-   * 获取封装的 postid
-   *
-   * @param postid
-   */
-  private getConfluencePostidKey(postid: string): any {
-    let pageId: string
-    let spaceKey: string
-    
-    if (postid.indexOf("_") > 0) {
-      const idArr = postid.split("_")
-      pageId = idArr[0]
-      spaceKey = idArr[1]
-    } else {
-      pageId = postid
+        const spaces: any[] = await this.getSpaces()
+        if (spaces && spaces.length > 0) {
+            spaces.forEach((space) => {
+                const cat = new CategoryInfo()
+                cat.categoryId = space.key
+                cat.categoryName = space.name
+                cat.description = space.name
+                cat.categoryDescription = space.name
+                cats.push(cat)
+            })
+        }
+
+        return cats
     }
 
-    return {
-      pageId,
-      spaceKey,
-    }
-  }
-
-  /**
-   * 向 Confluence 请求数据
-   *
-   * @param url 请求地址
-   * @param params 数据
-   * @param method 请求方法 GET | POST | PUT | DELETE
-   */
-  private async confluenceRequest(
-    url: string,
-    params?: any,
-    method: "GET" | "POST" | "PUT" | "DELETE" = "POST"
-  ): Promise<any> {
-    const apiUrl = `${this.cfg.apiUrl}${url}`
-    this.logger.debug("向 Confluence 请求数据，apiUrl =>", apiUrl)
-    this.logger.debug("向 Confluence 请求数据，params =>", params)
-
-    let finalUrl = apiUrl
-    let body: string | undefined = undefined
-
-    if (method === "GET" && params && !ObjectUtil.isEmptyObject(params)) {
-      // GET 请求将参数放到 URL 中
-      const queryParams = new URLSearchParams(params).toString()
-      finalUrl = `${apiUrl}?${queryParams}`
-    } else if (method !== "GET") {
-      // POST/PUT/DELETE 请求将参数放到 body 中
-      body = ObjectUtil.isEmptyObject(params) ? undefined : JSON.stringify(params)
+    public async getPreviewUrl(postid: string): Promise<string> {
+        const purl = this.cfg.previewUrl ?? ""
+        const confluencePostidKey = this.getConfluencePostidKey(postid)
+        const pageId = confluencePostidKey.pageId
+        const spaceKey = confluencePostidKey.spaceKey ?? this.cfg.blogid ?? ""
+        const postUrl = purl.replace("[postid]", pageId).replace("[spaceKey]", spaceKey)
+        return postUrl
     }
 
-    // 使用原生 fetch 直接请求 Confluence API
-    // 这样可以确保所有必要的请求头都被正确发送
-    try {
-      const response = await fetch(finalUrl, {
-        method: method,
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${this.cfg.password}`,
-          "X-Atlassian-Token": "no-check",
-          "Accept": "application/json",
-        },
-        body: body,
-        credentials: "include",
-      })
+    // ================
+    // private methods
+    // ================
 
-      this.logger.debug("Confluence API 响应状态 =>", response.status)
-
-      if (!response.ok) {
-        const errorText = await response.text()
-        this.logger.error("Confluence API 请求失败 =>", errorText)
-        throw new Error(`Confluence API 请求失败: ${response.status} ${response.statusText}`)
-      }
-
-      const resJson = await response.json()
-      this.logger.debug("向 Confluence 请求数据，resJson =>", resJson)
-      
-      return resJson
-    } catch (error) {
-      this.logger.error("Confluence API 请求异常 =>", error)
-      throw error
+    /**
+     * 获取 Confluence 空间列表
+     */
+    private async getSpaces() {
+        const url = "/rest/api/space"
+        const params = {
+            limit: 100,
+        }
+        const result = await this.confluenceRequest(url, params, "GET")
+        this.logger.debug("confluence spaces=>", result)
+        return result.results || []
     }
-  }
+
+    /**
+     * 创建 Confluence 页面
+     *
+     * @param title 标题
+     * @param content 内容（HTML格式）
+     * @param spaceKey 空间key
+     */
+    private async createPage(title: string, content: string, spaceKey?: string): Promise<string> {
+        const url = "/rest/api/content"
+        const targetSpaceKey = spaceKey || this.cfg.blogid
+        const parentPageId = this.cfg.parentPageId?.trim()
+
+        const params: Record<string, any> = {
+            type: "page",
+            title: title,
+            space: {
+                key: targetSpaceKey,
+            },
+            body: {
+                storage: {
+                    value: content,
+                    representation: "storage",
+                },
+            },
+        }
+
+        if (parentPageId) {
+            // 允许指定父页面以在其下创建新页面
+            params["ancestors"] = [
+                {
+                    id: parentPageId,
+                },
+            ]
+        }
+
+        const result = await this.confluenceRequest(url, params, "POST")
+        this.logger.debug("confluence createPage=>", result)
+
+        if (!result || !result.id) {
+            throw new Error("请求 Confluence API 异常")
+        }
+
+        // 包含了空间key需要返回标识空间的ID，否则更新可能报错
+        if (targetSpaceKey) {
+            return `${result.id}_${targetSpaceKey}`
+        } else {
+            return `${result.id}`
+        }
+    }
+
+    public async getPagesBySpace(spaceKey: string): Promise<{ id: string; title: string }[]> {
+        const url = "/rest/api/content"
+        const params = {
+            spaceKey,
+            type: "page",
+            limit: 200,
+            expand: "ancestors"
+        }
+        const result = await this.confluenceRequest(url, params, "GET")
+        this.logger.debug("confluence pages list=>", result)
+        return (result?.results ?? []).map((item: any) => ({ id: item.id, title: item.title }))
+    }
+
+    /**
+     * 更新 Confluence 页面
+     *
+     * @param pageId 页面ID
+     * @param title 标题
+     * @param content 内容（HTML格式）
+     * @param spaceKey 空间key
+     */
+    private async updatePage(
+        pageId: string,
+        title: string,
+        content: string,
+        spaceKey?: string
+    ): Promise<boolean> {
+        // 先获取页面当前版本
+        const page = await this.getPage(pageId)
+        const currentVersion = page.version.number
+
+        const url = `/rest/api/content/${pageId}`
+        const params = {
+            id: pageId,
+            type: "page",
+            title: title,
+            version: {
+                number: currentVersion + 1,
+            },
+            body: {
+                storage: {
+                    value: content,
+                    representation: "storage",
+                },
+            },
+        }
+
+        const result = await this.confluenceRequest(url, params, "PUT")
+        if (!result) {
+            throw new Error("请求 Confluence API 异常")
+        }
+
+        return true
+    }
+
+    /**
+     * 获取 Confluence 页面
+     *
+     * @param pageId 页面ID
+     */
+    private async getPage(pageId: string): Promise<any> {
+        const url = `/rest/api/content/${pageId}`
+        const params = {
+            expand: "body.storage,version,space",
+        }
+        const result = await this.confluenceRequest(url, params, "GET")
+
+        if (!result) {
+            throw new Error("请求 Confluence API 异常")
+        }
+
+        return result
+    }
+
+    /**
+     * 删除 Confluence 页面
+     *
+     * @param pageId 页面ID
+     */
+    private async deletePage(pageId: string): Promise<boolean> {
+        const url = `/rest/api/content/${pageId}`
+        const result = await this.confluenceRequest(url, {}, "DELETE")
+
+        if (!result) {
+            throw new Error("请求 Confluence API 异常")
+        }
+
+        return true
+    }
+
+    /**
+     * 获取封装的 postid
+     *
+     * @param postid
+     */
+    private getConfluencePostidKey(postid: string): any {
+        let pageId: string
+        let spaceKey: string
+
+        if (postid.indexOf("_") > 0) {
+            const idArr = postid.split("_")
+            pageId = idArr[0]
+            spaceKey = idArr[1]
+        } else {
+            pageId = postid
+        }
+
+        return {
+            pageId,
+            spaceKey,
+        }
+    }
+
+    /**
+     * 向 Confluence 请求数据
+     *
+     * @param url 请求地址
+     * @param params 数据
+     * @param method 请求方法 GET | POST | PUT | DELETE
+     */
+    private async confluenceRequest(
+        url: string,
+        params?: any,
+        method: "GET" | "POST" | "PUT" | "DELETE" = "POST"
+    ): Promise<any> {
+        const apiUrl = `${this.cfg.apiUrl}${url}`
+        this.logger.debug("向 Confluence 请求数据，apiUrl =>", apiUrl)
+        this.logger.debug("向 Confluence 请求数据，params =>", params)
+
+        let finalUrl = apiUrl
+        let body: string | undefined = undefined
+
+        if (method === "GET" && params && !ObjectUtil.isEmptyObject(params)) {
+            // GET 请求将参数放到 URL 中
+            const queryParams = new URLSearchParams(params).toString()
+            finalUrl = `${apiUrl}?${queryParams}`
+        } else if (method !== "GET") {
+            // POST/PUT/DELETE 请求将参数放到 body 中
+            body = ObjectUtil.isEmptyObject(params) ? undefined : JSON.stringify(params)
+        }
+
+        // 使用原生 fetch 直接请求 Confluence API
+        // 这样可以确保所有必要的请求头都被正确发送
+        try {
+            const response = await fetch(finalUrl, {
+                method: method,
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${this.cfg.password}`,
+                    "X-Atlassian-Token": "no-check",
+                    "Accept": "application/json",
+                },
+                body: body,
+                credentials: "include",
+            })
+
+            this.logger.debug("Confluence API 响应状态 =>", response.status)
+
+            if (!response.ok) {
+                const errorText = await response.text()
+                this.logger.error("Confluence API 请求失败 =>", errorText)
+                throw new Error(`Confluence API 请求失败: ${response.status} ${response.statusText}`)
+            }
+
+            const resJson = await response.json()
+            this.logger.debug("向 Confluence 请求数据，resJson =>", resJson)
+
+            return resJson
+        } catch (error) {
+            this.logger.error("Confluence API 请求异常 =>", error)
+            throw error
+        }
+    }
 }
 
 export { ConfluenceApiAdaptor }

--- a/src/adaptors/api/confluence/confluenceConfig.ts
+++ b/src/adaptors/api/confluence/confluenceConfig.ts
@@ -30,24 +30,27 @@ import { CommonBlogConfig } from "~/src/adaptors/api/base/commonBlogConfig.ts"
  * Confluence 配置
  */
 class ConfluenceConfig extends CommonBlogConfig {
-  constructor(home: string, apiUrl: string, password: string, middlewareUrl?: string) {
-    super(home, apiUrl, "", password, middlewareUrl)
+    public parentPageId?: string
 
-    this.tokenSettingUrl = home + "/wiki/users/viewmyprofile.action"
-    this.showTokenTip = true
-    this.previewUrl = "/wiki/spaces/[spaceKey]/pages/[postid]"
-    this.pageType = PageTypeEnum.Html
-    this.usernameEnabled = false
-    this.passwordType = PasswordType.PasswordType_Token
-    this.allowPreviewUrlChange = false
-    this.tagEnabled = false
-    this.cateEnabled = false
-    this.knowledgeSpaceEnabled = true
-    this.knowledgeSpaceTitle = "空间"
-    this.allowKnowledgeSpaceChange = true
-    this.placeholder.knowledgeSpaceReadonlyModeTip =
-      "由于 Confluence 平台的限制，暂时不支持编辑所属空间。如果您想移动文档，请先点击取消删除该文档，然后重新选择新的空间发布"
-  }
+    constructor(home: string, apiUrl: string, password: string, middlewareUrl?: string) {
+        super(home, apiUrl, "", password, middlewareUrl)
+
+        this.tokenSettingUrl = home + "/wiki/users/viewmyprofile.action"
+        this.showTokenTip = true
+        this.previewUrl = "/wiki/spaces/[spaceKey]/pages/[postid]"
+        this.pageType = PageTypeEnum.Html
+        this.usernameEnabled = false
+        this.passwordType = PasswordType.PasswordType_Token
+        this.allowPreviewUrlChange = false
+        this.tagEnabled = false
+        this.cateEnabled = false
+        this.knowledgeSpaceEnabled = true
+        this.knowledgeSpaceTitle = "空间"
+        this.allowKnowledgeSpaceChange = true
+        this.parentPageId = ""
+        this.placeholder.knowledgeSpaceReadonlyModeTip =
+            "由于 Confluence 平台的限制，暂时不支持编辑所属空间。如果您想移动文档，请先点击取消删除该文档，然后重新选择新的空间发布"
+    }
 }
 
 export { ConfluenceConfig }

--- a/src/adaptors/api/confluence/useConfluenceApi.ts
+++ b/src/adaptors/api/confluence/useConfluenceApi.ts
@@ -35,62 +35,63 @@ import { CategoryTypeEnum } from "zhi-blog-api"
 import { LEGENCY_SHARED_PROXT_MIDDLEWARE } from "~/src/utils/constants.ts"
 
 const useConfluenceApi = async (key: string, newCfg?: ConfluenceConfig) => {
-  // 创建应用日志记录器
-  const logger = createAppLogger("use-confluence-api")
+    // 创建应用日志记录器
+    const logger = createAppLogger("use-confluence-api")
 
-  // 记录开始使用 Confluence API
-  logger.info("Start using Confluence API...")
+    // 记录开始使用 Confluence API
+    logger.info("Start using Confluence API...")
 
-  // 创建应用实例
-  const appInstance = new PublisherAppInstance()
+    // 创建应用实例
+    const appInstance = new PublisherAppInstance()
 
-  let cfg: ConfluenceConfig
-  if (newCfg) {
-    logger.info("Initialize with the latest newCfg passed in...")
-    cfg = newCfg
-  } else {
-    // 从配置中获取数据
-    const { getSetting } = usePublishSettingStore()
-    const setting = await getSetting()
-    cfg = JsonUtil.safeParse<ConfluenceConfig>(setting[key], {} as ConfluenceConfig)
-
-    // 如果配置为空，则使用默认的环境变量值，并记录日志
-    if (ObjectUtil.isEmptyObject(cfg)) {
-      // 从环境变量获取 Confluence API 的 URL、认证令牌和其他配置信息
-      const confluenceHome = Utils.emptyOrDefault(process.env.VITE_CONFLUENCE_HOME, "")
-      const confluenceAuthToken = Utils.emptyOrDefault(process.env.VITE_CONFLUENCE_AUTH_TOKEN, "")
-      const middlewareUrl = Utils.emptyOrDefault(process.env.VITE_MIDDLEWARE_URL, LEGENCY_SHARED_PROXT_MIDDLEWARE)
-      cfg = new ConfluenceConfig(confluenceHome, confluenceHome, confluenceAuthToken, middlewareUrl)
-      logger.info("Configuration is empty, using default environment variables.")
+    let cfg: ConfluenceConfig
+    if (newCfg) {
+        logger.info("Initialize with the latest newCfg passed in...")
+        cfg = newCfg
     } else {
-      logger.info("Using configuration from settings...")
+        // 从配置中获取数据
+        const { getSetting } = usePublishSettingStore()
+        const setting = await getSetting()
+        cfg = JsonUtil.safeParse<ConfluenceConfig>(setting[key], {} as ConfluenceConfig)
+
+        // 如果配置为空，则使用默认的环境变量值，并记录日志
+        if (ObjectUtil.isEmptyObject(cfg)) {
+            // 从环境变量获取 Confluence API 的 URL、认证令牌和其他配置信息
+            const confluenceHome = Utils.emptyOrDefault(process.env.VITE_CONFLUENCE_HOME, "")
+            const confluenceAuthToken = Utils.emptyOrDefault(process.env.VITE_CONFLUENCE_AUTH_TOKEN, "")
+            const middlewareUrl = Utils.emptyOrDefault(process.env.VITE_MIDDLEWARE_URL, LEGENCY_SHARED_PROXT_MIDDLEWARE)
+            cfg = new ConfluenceConfig(confluenceHome, confluenceHome, confluenceAuthToken, middlewareUrl)
+            logger.info("Configuration is empty, using default environment variables.")
+        } else {
+            logger.info("Using configuration from settings...")
+        }
+        // 初始化posidKey
+        if (StrUtil.isEmptyString(cfg.posidKey)) {
+            // 默认值
+            cfg.posidKey = getDynPostidKey(key)
+        }
     }
-    // 初始化posidKey
-    if (StrUtil.isEmptyString(cfg.posidKey)) {
-      // 默认值
-      cfg.posidKey = getDynPostidKey(key)
+
+    // 标签
+    cfg.tagEnabled = false
+    // Confluence 使用单选分类作为空间
+    cfg.cateEnabled = false
+    cfg.knowledgeSpaceEnabled = true
+    cfg.knowledgeSpaceType = CategoryTypeEnum.CategoryType_Single
+    cfg.allowKnowledgeSpaceChange = true
+    cfg.parentPageId = cfg.parentPageId ?? ""
+    // picbed service
+    cfg.picgoPicbedSupported = true
+    cfg.bundledPicbedSupported = false
+
+    // 创建 Confluence API 适配器
+    const blogApi = new ConfluenceApiAdaptor(appInstance, cfg)
+    logger.info("Confluence API created successfully.", cfg)
+
+    return {
+        cfg,
+        blogApi,
     }
-  }
-
-  // 标签
-  cfg.tagEnabled = false
-  // Confluence 使用单选分类作为空间
-  cfg.cateEnabled = false
-  cfg.knowledgeSpaceEnabled = true
-  cfg.knowledgeSpaceType = CategoryTypeEnum.CategoryType_Single
-  cfg.allowKnowledgeSpaceChange = true
-  // picbed service
-  cfg.picgoPicbedSupported = true
-  cfg.bundledPicbedSupported = false
-
-  // 创建 Confluence API 适配器
-  const blogApi = new ConfluenceApiAdaptor(appInstance, cfg)
-  logger.info("Confluence API created successfully.", cfg)
-
-  return {
-    cfg,
-    blogApi,
-  }
 }
 
 export { useConfluenceApi }

--- a/src/locales/en_US.ts
+++ b/src/locales/en_US.ts
@@ -390,6 +390,8 @@ export default {
         "Personal Access Token for the Confluence platform, please create it in personal settings with read and write permissions for spaces",
     "setting.confluence.apiurl.tip": "The API address of the Confluence platform, usually same as the homepage",
     "setting.confluence.previewUrl.tip": "Article preview rules for the Confluence platform, usually: /wiki/spaces/[spaceKey]/pages/[postid]",
+    "setting.confluence.parentPageId.label": "Parent page ID",
+    "setting.confluence.parentPageId.tip": "Optional. When filled, new pages will be created under the specified parent page (e.g. 327683)",
 
     "setting.liandi.home.tip": "The homepage of the chain drop platform is usually fixed: https://ld246.com/",
     "setting.liandi.username.tip":

--- a/src/locales/zh_CN.ts
+++ b/src/locales/zh_CN.ts
@@ -383,6 +383,8 @@ export default {
         "Confluence平台的Personal Access Token，请在个人设置中创建，需要有空间的读写权限",
     "setting.confluence.apiurl.tip": "Confluence平台的API地址，通常与首页地址相同",
     "setting.confluence.previewUrl.tip": "Confluence平台的文章预览规则，通常是：/wiki/spaces/[spaceKey]/pages/[postid]",
+    "setting.confluence.parentPageId.label": "父页面ID",
+    "setting.confluence.parentPageId.tip": "可选，填写后将在该父页面下创建新页面，例如 327683",
 
     "setting.liandi.home.tip": "链滴平台首页，通常固定是：https://ld246.com/",
     "setting.liandi.username.tip":


### PR DESCRIPTION
You can create a new page under the parent page ID, optional; if not selected, it will be at the same level as the parent page.
As follows:
<img width="1841" height="684" alt="image" src="https://github.com/user-attachments/assets/c02a71f7-610c-43c3-aff6-60070122063a" />
